### PR TITLE
add(mcp_server deploy): support mcp_server deployment

### DIFF
--- a/lazyllm/cli/deploy.py
+++ b/lazyllm/cli/deploy.py
@@ -1,25 +1,95 @@
-import argparse
+import os
+import sys
 import time
+import argparse
+import asyncio
+
+import lazyllm
+from lazyllm.common import str2bool
+
 
 def deploy(commands):
-    import lazyllm
-    parser = argparse.ArgumentParser(description="lazyllm deploy command")
-    parser.add_argument("model", help="model name")
-    parser.add_argument("--framework", help="deploy framework", default="auto",
-                        choices=["auto", "vllm", "lightllm", "lmdeploy"])
-    parser.add_argument("--chat", help="chat ", default='false',
-                        choices=["ON", "on", "1", "true", "True", "OFF", "off", "0", "False", "false"])
+    parser = argparse.ArgumentParser(
+        description=(
+            "lazyllm deploy command for deploying a model or a mcp server."
+        ),
+        epilog=(
+            "Examples:\n",
+            "lazyllm deploy model internlm2-chat-20b",
+            "lazyllm deploy model internlm2-chat-20b --framework vllm",
+            "lazyllm deploy mcp_server uvx mcp-server-fetch",
+            "lazyllm python deploy mcp_server -e GITHUB_PERSONAL_ACCESS_TOKEN your_token --sse-port 8080 npx -- -y @modelcontextprotocol/server-github"
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    subparsers = parser.add_subparsers(dest="deploy_type", required=True, help="Deployment type")
+
+    # subcommand: deploy a model
+    model_parser = subparsers.add_parser("model", help="Deploy a model")
+    model_parser.add_argument("model", help="Model name (for model deployment)")
+    model_parser.add_argument("--framework", help="Deploy framework", default="auto",
+                              choices=["auto", "vllm", "lightllm", "lmdeploy"])
+    model_parser.add_argument("--chat", help="Enable chat", default=False, type=str2bool)
+
+    # subcommand: deploy an MCP server
+    mcp_parser = subparsers.add_parser("mcp_server", help="Deploy an MCP server")
+    mcp_parser.add_argument("command", help="Command to spawn the server. Do not provide an HTTP URL.")
+    mcp_parser.add_argument("args", nargs="*", help="Extra arguments for the command to spawn the server")
+    mcp_parser.add_argument("-e", "--env", nargs=2, action="append", metavar=("KEY", "VALUE"),
+                            help="Environment variables for spawning the server. Can be used multiple times.",
+                            default=[])
+    mcp_parser.add_argument("--pass-environment", action=argparse.BooleanOptionalAction,
+                            help="Pass through all environment variables when spawning the server.",
+                            default=False)
+    mcp_parser.add_argument("--sse-port", type=int, default=0,
+                            help="Port to expose an SSE server on. Default is a random port")
+    mcp_parser.add_argument("--sse-host", default="127.0.0.1",
+                            help="Host to expose an SSE server on. Default is 127.0.0.1")
+    mcp_parser.add_argument("--allow-origin", nargs="+", default=[],
+                            help="Allowed origins for the SSE server. Can be used multiple times. Default is no CORS allowed.")
 
     args = parser.parse_args(commands)
 
-    t = lazyllm.TrainableModule(args.model).deploy_method(getattr(lazyllm.deploy, args.framework))
-    if args.chat in ["ON", "on", "1", "true", "True"]:
-        t = lazyllm.WebModule(t)
-    t.start()
-    if args.chat in ["ON", "on", "1", "true", "True"]:
-        t.wait()
+    if args.deploy_type == "model":
+        # deploy a model
+        deploy_framework = getattr(lazyllm.deploy, args.framework)
+        t = lazyllm.TrainableModule(args.model).deploy_method(deploy_framework)
+        if args.chat:
+            t = lazyllm.WebModule(t)
+        t.start()
+        if args.chat:
+            t.wait()
+        else:
+            lazyllm.LOG.success(
+                f'LazyLLM TrainableModule launched successfully:\n  URL: {t._url}\n  Framework: {t._deploy_type.__name__}',
+                flush=True
+            )
+            try:
+                while True:
+                    time.sleep(10)
+            except KeyboardInterrupt:
+                sys.exit(0)
+
+    elif args.deploy_type == "mcp_server":
+        # deploy an MCP server
+        env: dict[str, str] = {}
+        if args.pass_environment:
+            env.update(os.environ)
+        env.update(dict(args.env))
+
+        lazyllm.LOG.debug("Starting stdio client and SSE server")
+
+        from lazyllm.tools.mcp.deploy import SseServerSettings
+        client = lazyllm.tools.MCPClient(command_or_url=args.command, args=args.args, env=env)
+        asyncio.run(
+            client.deploy(
+                sse_settings=SseServerSettings(
+                    bind_host=args.sse_host,
+                    port=args.sse_port,
+                    allow_origins=args.allow_origin,
+                )
+            )
+        )
     else:
-        lazyllm.LOG.success(f'LazyLLM TrainableModule launched successfully:\n  URL: {t._url}\n  '
-                            f'Framework: {t._deploy_type.__name__}', flush=True)
-        while True:
-            time.sleep(10)
+        parser.error(f"Unsupported deploy type: {args.deploy_type}")

--- a/lazyllm/common/__init__.py
+++ b/lazyllm/common/__init__.py
@@ -12,7 +12,7 @@ from .deprecated import deprecated
 from .globals import globals, LazyLlmResponse, LazyLlmRequest, encode_request, decode_request
 from .bind import root, Bind as bind, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9
 from .queue import FileSystemQueue
-from .utils import compile_func, obj2str, str2obj
+from .utils import compile_func, obj2str, str2obj, str2bool
 
 __all__ = [
     # registry
@@ -38,6 +38,7 @@ __all__ = [
     'colored_text',
     'obj2str',
     'str2obj',
+    'str2bool',
 
     # arg praser
     'LazyLLMCMD',

--- a/lazyllm/common/utils.py
+++ b/lazyllm/common/utils.py
@@ -5,6 +5,7 @@ import re
 import ast
 import pickle
 import base64
+import argparse
 
 def check_path(
     path: Union[str, PathLike],
@@ -42,3 +43,14 @@ def obj2str(obj: Any) -> str:
 
 def str2obj(data: str) -> Any:
     return None if data is None else pickle.loads(base64.b64decode(data.encode('utf-8')))
+
+def str2bool(v: str) -> bool:
+    """ Boolean type converter """
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1', 'on'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0', 'off'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')

--- a/lazyllm/tools/mcp/client.py
+++ b/lazyllm/tools/mcp/client.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from contextlib import asynccontextmanager
 
 from .tool_adaptor import generate_lazyllm_tool
+from .deploy import SseServerSettings, start_sse_server
 
 
 class MCPClient(ClientSession):
@@ -56,3 +57,6 @@ class MCPClient(ClientSession):
         
         return [generate_lazyllm_tool(self, tool) for tool in mcp_tools]
     
+    async def deploy(self, sse_settings: SseServerSettings):
+        async with self._run_session() as session:
+            await start_sse_server(session, sse_settings)

--- a/lazyllm/tools/mcp/deploy.py
+++ b/lazyllm/tools/mcp/deploy.py
@@ -1,0 +1,207 @@
+import uvicorn
+
+from dataclasses import dataclass
+from typing import Literal, Any, Optional, List
+
+from mcp import types
+from mcp.server import Server
+from mcp.server.sse import SseServerTransport
+from mcp.client.session import ClientSession
+
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.routing import Mount, Route
+
+
+@dataclass
+class SseServerSettings:
+    """Settings for the SSE server."""
+    bind_host: str
+    port: int
+    allow_origins: Optional[List[str]] = None
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+
+
+def _create_starlette_app(
+    mcp_server: Server[Any],
+    *,
+    allow_origins: Optional[List[str]] = None,
+    debug: bool = False,
+) -> Starlette:
+    """
+    Create a Starlette application to serve the provided MCP server with SSE.
+    
+    Args:
+        mcp_server: The MCP server instance.
+        allow_origins: Allowed origins for CORS middleware.
+        debug: Flag indicating whether to enable debug mode.
+    
+    Returns:
+        A configured Starlette application.
+    """
+    sse = SseServerTransport("/messages/")
+
+    async def handle_sse(request: Request) -> None:
+        async with sse.connect_sse(
+            request.scope,
+            request.receive,
+            request._send,  # noqa: SLF001
+        ) as (read_stream, write_stream):
+            await mcp_server.run(
+                read_stream,
+                write_stream,
+                mcp_server.create_initialization_options(),
+            )
+
+    middleware: List[Middleware] = []
+    if allow_origins:
+        middleware.append(
+            Middleware(
+                CORSMiddleware,
+                allow_origins=allow_origins,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
+        )
+
+    return Starlette(
+        debug=debug,
+        middleware=middleware,
+        routes=[
+            Route("/sse", endpoint=handle_sse),
+            Mount("/messages/", app=sse.handle_post_message),
+        ],
+    )
+
+
+async def _create_proxy_server(remote_app: ClientSession) -> Server[Any]:
+    """
+    Create a proxy server instance based on a remote client session.
+    
+    Args:
+        remote_app: A client session for a remote MCP application.
+    
+    Returns:
+        An instance of Server with request and notification handlers mapped.
+    """
+    response = await remote_app.initialize()
+    capabilities = response.capabilities
+
+    server_instance: Server[Any] = Server(name=response.serverInfo.name)
+
+    if capabilities.prompts:
+        async def _list_prompts(_: Any) -> types.ServerResult:
+            result = await remote_app.list_prompts()
+            return types.ServerResult(result)
+
+        async def _get_prompt(req: types.GetPromptRequest) -> types.ServerResult:
+            result = await remote_app.get_prompt(req.params.name, req.params.arguments)
+            return types.ServerResult(result)
+
+        server_instance.request_handlers[types.ListPromptsRequest] = _list_prompts
+        server_instance.request_handlers[types.GetPromptRequest] = _get_prompt
+
+    if capabilities.resources:
+        async def _subscribe_resource(req: types.SubscribeRequest) -> types.ServerResult:
+            await remote_app.subscribe_resource(req.params.uri)
+            return types.ServerResult(types.EmptyResult())
+
+        async def _unsubscribe_resource(req: types.UnsubscribeRequest) -> types.ServerResult:
+            await remote_app.unsubscribe_resource(req.params.uri)
+            return types.ServerResult(types.EmptyResult())
+
+        async def _list_resources(_: Any) -> types.ServerResult:
+            result = await remote_app.list_resources()
+            return types.ServerResult(result)
+
+        async def _read_resource(req: types.ReadResourceRequest) -> types.ServerResult:
+            result = await remote_app.read_resource(req.params.uri)
+            return types.ServerResult(result)
+
+        server_instance.request_handlers[types.SubscribeRequest] = _subscribe_resource
+        server_instance.request_handlers[types.UnsubscribeRequest] = _unsubscribe_resource
+        server_instance.request_handlers[types.ListResourcesRequest] = _list_resources
+        server_instance.request_handlers[types.ReadResourceRequest] = _read_resource
+
+    if capabilities.logging:
+        async def _set_logging_level(req: types.SetLevelRequest) -> types.ServerResult:
+            await remote_app.set_logging_level(req.params.level)
+            return types.ServerResult(types.EmptyResult())
+
+        server_instance.request_handlers[types.SetLevelRequest] = _set_logging_level
+
+    if capabilities.tools:
+        async def _list_tools(_: Any) -> types.ServerResult:
+            tools = await remote_app.list_tools()
+            return types.ServerResult(tools)
+
+        async def _call_tool(req: types.CallToolRequest) -> types.ServerResult:
+            try:
+                result = await remote_app.call_tool(
+                    req.params.name,
+                    req.params.arguments or {},
+                )
+                return types.ServerResult(result)
+            except Exception as e:
+                return types.ServerResult(
+                    types.CallToolResult(
+                        content=[types.TextContent(type="text", text=str(e))],
+                        isError=True,
+                    )
+                )
+
+        server_instance.request_handlers[types.ListToolsRequest] = _list_tools
+        server_instance.request_handlers[types.CallToolRequest] = _call_tool
+
+    async def _send_progress_notification(req: types.ProgressNotification) -> None:
+        await remote_app.send_progress_notification(
+            req.params.progressToken,
+            req.params.progress,
+            req.params.total,
+        )
+
+    server_instance.notification_handlers[types.ProgressNotification] = _send_progress_notification
+
+    async def _complete(req: types.CompleteRequest) -> types.ServerResult:
+        result = await remote_app.complete(
+            req.params.ref,
+            req.params.argument.model_dump(),
+        )
+        return types.ServerResult(result)
+
+    server_instance.request_handlers[types.CompleteRequest] = _complete
+
+    return server_instance
+
+
+async def start_sse_server(
+    client_session: ClientSession,
+    sse_settings: SseServerSettings,
+) -> None:
+    """
+    Start the SSE server by creating a proxy MCP server and serving it via Starlette.
+    
+    Args:
+        client_session: The client session for the remote MCP app.
+        sse_settings: The settings for configuring the SSE server.
+    """
+    mcp_server = await _create_proxy_server(client_session)
+
+    # Create the Starlette app with SSE routes and middleware.
+    starlette_app = _create_starlette_app(
+        mcp_server,
+        allow_origins=sse_settings.allow_origins,
+        debug=(sse_settings.log_level == "DEBUG"),
+    )
+
+    # Configure and start the HTTP server using uvicorn.
+    config = uvicorn.Config(
+        starlette_app,
+        host=sse_settings.bind_host,
+        port=sse_settings.port,
+        log_level=sse_settings.log_level.lower(),
+    )
+    http_server = uvicorn.Server(config)
+    await http_server.serve()


### PR DESCRIPTION
example：
command：
```
lazyllm deploy mcp_server --sse-port 11287 npx -- -y @modelcontextprotocol/server-filesystem ./output/
```
![image](https://github.com/user-attachments/assets/e190bce5-fb3a-4aa3-823b-dc611008daaf)


lazyllm code:
```
config = {"remote_fetch":{"url":"http://127.0.0.1:11287/sse"}}
file_sys_config = config["remote_fetch"]
client = MCPClient(command_or_url=file_sys_config["url"])
llm = OnlineChatModule(source="deepseek", stream=False)
tools = asyncio.run(client.get_tools())
agent = ReactAgent(llm.share(), tools2)
print(agent2("写一首关于月亮的诗，并保存在目录中，叫'moon.txt'"))
```
![image](https://github.com/user-attachments/assets/52484ade-5887-429c-837a-ed019ac463ee)
